### PR TITLE
Add missing --force definition

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ Usage:
                 [--exclude-prefix EXPREFIX]...
                 [--token TOKEN]
                 [--no-prompt]
+                [--force]
                 <filename>
   consul-bak dumptree
                 [--leader-only]


### PR DESCRIPTION
Due to --force not being parsed as an option it is nil, which results in
an interface-conversion panic.